### PR TITLE
proxy listener port changed to +5k instead of 10+ for ports under 1024

### DIFF
--- a/proxy/listener.go
+++ b/proxy/listener.go
@@ -36,7 +36,7 @@ func NewProxyListener(m mux.MuxClient, logger *log.Logger) *ProxyListener {
 func (p *ProxyListener) NewListener(rport uint16) (lport uint16, err error) {
 	lport = rport
 	if rport < 1024 {
-		lport = rport + 10000
+		lport = rport + 5000
 	}
 	lport, err = p.newListener(lport, rport)
 	if errors.Is(err, syscall.EADDRINUSE) {


### PR DESCRIPTION
Chrome and Safari seem to have problems with ports over 10.000 and block them by default. 
This changes the proxy listener to add only 5000 instead of 10000 to all port numbers under 1024. 
